### PR TITLE
Fix missing/bad address line handling

### DIFF
--- a/bfd/dwarf2.c
+++ b/bfd/dwarf2.c
@@ -1325,9 +1325,7 @@ new_line_sorts_after (struct line_info *new_line, struct line_info *line)
 {
   return (new_line->address > line->address
 	  || (new_line->address == line->address
-	      && (new_line->op_index > line->op_index
-		  || (new_line->op_index == line->op_index
-		      && new_line->end_sequence < line->end_sequence))));
+	      && new_line->op_index > line->op_index));
 }
 
 
@@ -1413,7 +1411,8 @@ add_line_info (struct line_info_table *table,
       table->sequences = seq;
       table->num_sequences++;
     }
-  else if (new_line_sorts_after (info, seq->last_line))
+  else if (info->end_sequence
+          || new_line_sorts_after (info, seq->last_line))
     {
       /* Normal case: add 'info' to the beginning of the current sequence.  */
       info->prev_line = seq->last_line;


### PR DESCRIPTION
This commit fixes (indirectly) _bfd_dwarf2_find_nearest_line, which returns
bogus results in certain occasions (e.g. when therere are line numbers which
refer to address 0 in the dwarf section). Also sometimes it didn't return
anything at all which was visible in objdump even though the debug sections had
the necessary information.

original commit from riscv-binutils-1.30:
20230942fe3674150ab661738d72f1618b3d4b1b

original message:
PR21957, addr2line incorrectly handles non-increasing sequences in line table

            PR 21957
            * dwarf2.c (new_line_sorts_after): Remove end_sequence comparison.
            (add_line_info): Always put end_sequence last.