### PR TITLE
gdb/riscv: Remove use of pseudo registers

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -457,28 +457,6 @@ riscv_return_value (struct gdbarch  *gdbarch,
   return RETURN_VALUE_REGISTER_CONVENTION;
 }
 
-/* Implement the pseudo_register_read gdbarch method.  */
-
-static enum register_status
-riscv_pseudo_register_read (struct gdbarch *gdbarch,
-			    struct regcache *regcache,
-			    int regnum,
-			    gdb_byte *buf)
-{
-  return regcache_raw_read (regcache, regnum, buf);
-}
-
-/* Implement the pseudo_register_write gdbarch method.  */
-
-static void
-riscv_pseudo_register_write (struct gdbarch *gdbarch,
-			     struct regcache *regcache,
-			     int cookednum,
-			     const gdb_byte *buf)
-{
-  regcache_raw_write (regcache, cookednum, buf);
-}
-
 /* Implement the register_type gdbarch method.  */
 
 static struct type *
@@ -1292,10 +1270,7 @@ riscv_gdbarch_init (struct gdbarch_info info,
   set_gdbarch_print_insn (gdbarch, print_insn_riscv);
 
   /* Register architecture.  */
-  set_gdbarch_pseudo_register_read (gdbarch, riscv_pseudo_register_read);
-  set_gdbarch_pseudo_register_write (gdbarch, riscv_pseudo_register_write);
   set_gdbarch_num_regs (gdbarch, RISCV_NUM_REGS);
-  set_gdbarch_num_pseudo_regs (gdbarch, RISCV_NUM_REGS);
   set_gdbarch_sp_regnum (gdbarch, RISCV_SP_REGNUM);
   set_gdbarch_pc_regnum (gdbarch, RISCV_PC_REGNUM);
   set_gdbarch_ps_regnum (gdbarch, RISCV_FP_REGNUM);


### PR DESCRIPTION
This is a backport of a patch that has been applied to the riscv GDB repo almost 3 years ago. I was annoyed enough to bisect what was causing the following error to continue to use the pulp fork (however, I wonder if this is even necessary - it would be nice to know what the fork offers that riscv upstream does not).

This fixes:

    internal-error: const char* tdesc_register_name(gdbarch*, int): Assertion `data->pseudo_register_name != NULL' failed.


The code making use of pseudo registers was initially intended to
support running 32-bit ABI files on 64-bit riscv targets.  However, the
implementation was incomplete, and broken.

For now I've removed all reference to pseudo registers from the riscv
target, we've not lost any functionality, and this cleans up failures in
the selftests.

Once the riscv target has matured a little we'll probably end up
bringing back some of the use of pseudo registers in order to better
support running 32-bit executables on a 64-bit target.